### PR TITLE
backport to fix rocm warp size blocking compiling issue

### DIFF
--- a/sgl-kernel/include/utils.h
+++ b/sgl-kernel/include/utils.h
@@ -315,7 +315,7 @@ inline bool getEnvEnablePDL() {
 #if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
 #define WARP_SIZE 64
 #else
-#define WARP_SIZE 32
+#error "Unsupported configuration for WARP_SIZE"
 #endif
 #endif
 

--- a/sgl-kernel/include/utils.h
+++ b/sgl-kernel/include/utils.h
@@ -312,7 +312,11 @@ inline bool getEnvEnablePDL() {
 #ifndef USE_ROCM
 #define WARP_SIZE 32
 #else
-#define WARP_SIZE warpSize  // 64
+#if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
+#define WARP_SIZE 64
+#else
+#define WARP_SIZE 32
+#endif
 #endif
 
 #if defined(__HIP_PLATFORM_AMD__)


### PR DESCRIPTION
Facing compiling issue  using dcgpucesh01:5000/lejunzhu/sglang:rocm_7.0.2_torch_2.8_test base images, backporting latest sglang fix: https://github.com/sgl-project/sglang/pull/9356/